### PR TITLE
Add native Audit module to consent records

### DIFF
--- a/POPULATE.sh
+++ b/POPULATE.sh
@@ -16,10 +16,13 @@ DOMAINS=(
   "azienda.it"
   "empresa.es"
   "organisatie.nl"
+  "bedrijf.be"
+  "korporacja.pl"
+  "foretag.se"
 )
 
 # ======================================
-# Permission Universe (6 total)
+# Permission Universe (10 total)
 # ======================================
 PERMISSION_KEYS=(
   "Marketing"
@@ -28,6 +31,10 @@ PERMISSION_KEYS=(
   "Alerts"
   "Promotions"
   "Compliance"
+  "Analytics"
+  "ThirdPartySharing"
+  "SMS_Notifications"
+  "Telemarketing"
 )
 
 # ======================================
@@ -36,9 +43,9 @@ PERMISSION_KEYS=(
 BUCKETS=(
   "marketing_campaign_dach_spring_2026"
   "marketing_campaign_nordics_sustainability_2026"
-  "marketing_campaign_nordics_sustainability_2027"
   "marketing_campaign_southern_europe_summer_2026"
   "product_update_eu_platform_q2_2026"
+  "product_update_eu_platform_q3_2026"
   "mobile_app_update_eu_release"
   "cloud_service_maintenance_eu"
   "internal_engineering_berlin"
@@ -50,6 +57,10 @@ BUCKETS=(
   "gdpr_mandatory_notifications_eu"
   "privacy_policy_updates_eu"
   "terms_of_service_changes_eu"
+  "webinar_series_q4_2026"
+  "trade_show_leads_berlin"
+  "ecommerce_cart_abandonment"
+  "user_research_panel"
 )
 
 # ======================================
@@ -57,25 +68,33 @@ BUCKETS=(
 # ======================================
 
 generate_email_permissions() {
-    local min=2
-    local max=6
-    local true_count=$(( RANDOM % (max - min + 1) + min ))
+    local bucket_perms=("$@")
+    local total_perms=${#bucket_perms[@]}
+    
+    # Randomly decide how many of the available bucket permissions will be true for this user
+    local true_count=$(( RANDOM % (total_perms + 1) ))
 
-    # Randomly select permissions to enable
-    mapfile -t ENABLED < <(
-        printf '%s\n' "${PERMISSION_KEYS[@]}" \
-        | shuf \
-        | head -n "$true_count"
-    )
+    if [[ $true_count -gt 0 ]]; then
+        mapfile -t ENABLED < <(
+            printf '%s\n' "${bucket_perms[@]}" \
+            | shuf \
+            | head -n "$true_count"
+        )
+    else
+        ENABLED=()
+    fi
 
-    # Build JSON true/false map
+    # Build JSON true/false map using only the bucket's assigned permissions
     local json=""
-    for perm in "${PERMISSION_KEYS[@]}"; do
-        if printf '%s\n' "${ENABLED[@]}" | grep -qx "$perm"; then
-            json+="\"$perm\": true,"
-        else
-            json+="\"$perm\": false,"
-        fi
+    for perm in "${bucket_perms[@]}"; do
+        local is_enabled="false"
+        for enabled_perm in "${ENABLED[@]}"; do
+            if [[ "$enabled_perm" == "$perm" ]]; then
+                is_enabled="true"
+                break
+            fi
+        done
+        json+="\"$perm\": $is_enabled,"
     done
 
     echo "${json%,}"
@@ -90,15 +109,23 @@ echo "Initialization: Generating ${#BUCKETS[@]} buckets..."
 for BUCKET_NAME in "${BUCKETS[@]}"; do
 
     NUM_EMAILS=$(( RANDOM % (MAX_EMAILS_PER_BUCKET - MIN_EMAILS_PER_BUCKET + 1) + MIN_EMAILS_PER_BUCKET ))
+    
+    # Randomly select between 3 and 7 permissions from the universe for this specific bucket
+    NUM_BUCKET_PERMS=$(( RANDOM % 5 + 3 ))
+    mapfile -t BUCKET_PERMISSIONS < <(
+        printf '%s\n' "${PERMISSION_KEYS[@]}" \
+        | shuf \
+        | head -n "$NUM_BUCKET_PERMS"
+    )
 
-    echo "Processing [$BUCKET_NAME]: $NUM_EMAILS users..."
+    echo "Processing [$BUCKET_NAME]: $NUM_EMAILS users with $NUM_BUCKET_PERMS available permissions..."
 
     for (( i=1; i<=NUM_EMAILS; i++ )); do
         USER_ID=$(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c 8)
         DOMAIN=${DOMAINS[$RANDOM % ${#DOMAINS[@]}]}
         EMAIL="${USER_ID}@${DOMAIN}"
 
-        PERMISSIONS_JSON=$(generate_email_permissions)
+        PERMISSIONS_JSON=$(generate_email_permissions "${BUCKET_PERMISSIONS[@]}")
 
         PAYLOAD=$(cat <<EOF
 [{
@@ -178,6 +205,28 @@ DE_RESPONSE=$(curl -s -X POST "$ADMIN_URL" \
 DE_FORM_ID=$(echo "$DE_RESPONSE" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
 echo "Created newsletter_de form: $DE_FORM_ID"
 
+# Create newsletter_fr form
+FR_RESPONSE=$(curl -s -X POST "$ADMIN_URL" \
+    -H "X-Api-Key: $API_KEY" \
+    -H "Content-Type: application/json" \
+    -d '{
+        "name": "French Newsletter",
+        "bucket": "newsletter_fr",
+        "permission": "Newsletter",
+        "allowedOrigins": ["http://localhost:5000", "http://localhost:5001", "http://localhost:8070"],
+        "language": "fr",
+        "isEnabled": true,
+        "formConfig": {
+            "title": "Abonnez-vous à la newsletter",
+            "description": "Recevez des mises à jour dans votre boîte de réception.",
+            "buttonText": "S'\''abonner",
+            "successMessage": "Merci de vous être abonné !"
+        }
+    }')
+
+FR_FORM_ID=$(echo "$FR_RESPONSE" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+echo "Created newsletter_fr form: $FR_FORM_ID"
+
 # Subscribe 2 emails to newsletter_nl
 if [[ -n "$NL_FORM_ID" ]]; then
     echo "Subscribing 2 emails to newsletter_nl..."
@@ -194,6 +243,17 @@ if [[ -n "$DE_FORM_ID" ]]; then
     echo "Subscribing 3 emails to newsletter_de..."
     for email in "hans.mueller@firma.de" "anna.schmidt@firma.de" "lukas.weber@unternehmen.eu"; do
         curl -s -o /dev/null -w "  %{http_code} $email\n" -X POST "$SUBSCRIBE_BASE/$DE_FORM_ID/subscribe" \
+            -H "Content-Type: application/json" \
+            -H "Origin: http://localhost:8070" \
+            -d "{\"email\": \"$email\", \"consent\": \"true\"}"
+    done
+fi
+
+# Subscribe 2 emails to newsletter_fr
+if [[ -n "$FR_FORM_ID" ]]; then
+    echo "Subscribing 2 emails to newsletter_fr..."
+    for email in "jean.dupont@societe.fr" "marie.curie@societe.fr"; do
+        curl -s -o /dev/null -w "  %{http_code} $email\n" -X POST "$SUBSCRIBE_BASE/$FR_FORM_ID/subscribe" \
             -H "Content-Type: application/json" \
             -H "Origin: http://localhost:8070" \
             -d "{\"email\": \"$email\", \"consent\": \"true\"}"

--- a/README.md
+++ b/README.md
@@ -4,37 +4,31 @@
 [![Last commit](https://img.shields.io/github/last-commit/melosso/beacon)](https://github.com/melosso/beacon/commits/main)
 [![Latest Release](https://img.shields.io/github/v/release/melosso/beacon)](https://github.com/melosso/beacon/releases/latest)
 
-This is **Beacon**, a lightweight consent and opt-out service built with .NET 10. Beacon manages email consent state independently of any ERP, CRM, or automation platform. It issues secure, temporary URLs for opt-out and preference changes, validates them without upstream dependencies, and exposes a simple API that other systems query before sending email.
+This is **Beacon**, a lightweight service for handling email consent and opt-outs—no bloat, no dependencies. Built on .NET 10, it works independently of your CRM, ERP, or marketing tools. Generate secure, temporary opt-out links, validate them instantly, and let other systems check consent status via a clean API.
 
 ![Screenshot of Beacon](https://github.com/melosso/beacon/blob/main/.github/images/screenshot.webp?raw=true)
 
-> Feel free to play around in our live demo instance, available on [beacon-demo.melosso.com](https://beacon-demo.melosso.com). Use `Beacon-Api-Key` as your access token.
+> Try it out! Feel free to play around in our live demo instance, available on [beacon-demo.melosso.com](https://beacon-demo.melosso.com). Use `Beacon-Api-Key` as your access token.
 
 ## What is Beacon?
 
-Beacon is a **centralized consent** and **communication-preference** service. It allows external systems (ERP, CRM, marketing tools, automation platforms) to store, check, and update email permission states through a single, consistent API.
+Beacon **centralizes consent and communication preferences**, so your other systems don’t have to. Organize permissions into **Buckets** (e.g., newsletters, campaigns) and let recipients manage their preferences via secure, embeddable links.
 
-Consent is organized into logical groupings called **Buckets** (for example: newsletters, campaigns, or customer programs). For every email address in a bucket, Beacon can generate a secure, temporary URL that lets recipients manage their own preferences. These URLs can be embedded directly into outgoing messages and validated independently using cryptographic signatures.
+### **How It Works**
+Beacon handles consent for your automation tools, simple and efficient:
 
-Beacon is designed to be:
+- Generates cryptographically signed opt-out URLs.
+- Validates permission changes without database lookups (unless configured otherwise).
+- Keeps your sending systems lightweight, no complicated logic required.
 
-* Decoupled: no business logic in your sending systems
-* Stateless where possible: token validation without upstream lookups
-* Extensible: usable as a standalone service or embedded into existing flows
+### **Built for Your Workflow**
+Beacon adapts to your setup:
 
-Beyond basic opt-out handling, Beacon also supports richer consent workflows such as signup forms, multiple permission states, and administrative management via its built-in web interface.
-
-**Noteworthy features include:**
-
-- **Token-based opt-out**: Secure HMAC-signed URLs that validate without database lookups (unless you want to)
-- **Multi-database support**: SQLite (default), SQL Server, PostgreSQL, MySQL
-- **Admin panel**: Web UI for managing buckets and viewing consent records
-- **Confirmation mails**: You can choose for (double) opt-in confirmations via e-mail notifications
-- **Form builder**: Create campaign and newsletter signup forms
-- **Granular permissions**: Set multiple permission states in a single API call
-- **Security first**: Encrypted data at rest, hashed emails, rate limiting
-
-In other words, Beacon provides a decoupled infrastructure for managing communication preferences, allowing you to externalize consent logic and opt-out processing from your primary data sources.
+- Supports **SQLite, SQL Server, PostgreSQL, and MySQL**.
+- Admin panel for managing consent buckets and records.
+- Optional double opt-in confirmations.
+- Form builder for signup pages.
+- Granular permissions and security (encrypted data, hashed emails, rate limiting).
 
 ## Getting Started
 

--- a/Source/Beacon.Core/Models/ConsentAuditEntry.cs
+++ b/Source/Beacon.Core/Models/ConsentAuditEntry.cs
@@ -1,0 +1,15 @@
+namespace Beacon.Core.Models;
+
+public sealed class ConsentAuditEntry
+{
+    public Guid Id { get; set; }
+    public required string Bucket { get; set; }
+    public required string EmailHash { get; set; }
+    public required string Permission { get; set; }
+    public ConsentStatus? OldStatus { get; set; }
+    public ConsentStatus NewStatus { get; set; }
+    public ConsentSource Source { get; set; }
+    public string? ActorId { get; set; }
+    public DateTime ChangedAt { get; set; }
+    public string? IpAddress { get; set; }
+}

--- a/Source/Beacon.Core/Services/ConsentService.cs
+++ b/Source/Beacon.Core/Services/ConsentService.cs
@@ -30,7 +30,7 @@ public sealed class ConsentService : IConsentService
         return record?.Status ?? ConsentStatus.OptedIn;
     }
 
-    public async Task ProcessOptOutAsync(string bucket, string email, string[] permissions, string token, ConsentSource source)
+    public async Task ProcessOptOutAsync(string bucket, string email, string[] permissions, string token, ConsentSource source, string? ipAddress = null)
     {
         var normalizedBucket = NormalizeBucket(bucket);
         var normalizedEmail = email.Trim().ToLowerInvariant();
@@ -51,14 +51,15 @@ public sealed class ConsentService : IConsentService
                 Status = ConsentStatus.OptedOut,
                 Source = source,
                 ChangedAt = DateTime.UtcNow,
-                TokenHash = tokenHash
+                TokenHash = tokenHash,
+                IpAddress = ipAddress
             };
 
             await _repository.UpsertAsync(record);
         }
     }
 
-    public async Task OverrideAsync(string bucket, string email, string permission, ConsentStatus status, string? customFieldsJson = null)
+    public async Task OverrideAsync(string bucket, string email, string permission, ConsentStatus status, string? customFieldsJson = null, string? actorId = null)
     {
         var normalizedBucket = NormalizeBucket(bucket);
         var normalizedEmail = email.Trim().ToLowerInvariant();
@@ -79,7 +80,7 @@ public sealed class ConsentService : IConsentService
             CustomFields = customFieldsJson
         };
 
-        await _repository.UpsertAsync(record);
+        await _repository.UpsertAsync(record, actorId);
     }
 
     public async Task<bool> EnsureAsync(string bucket, string email, string permission, ConsentStatus status, string? customFieldsJson = null, string? ipAddress = null, string? consentText = null)

--- a/Source/Beacon.Core/Services/IConsentRepository.cs
+++ b/Source/Beacon.Core/Services/IConsentRepository.cs
@@ -5,7 +5,8 @@ namespace Beacon.Core.Services;
 public interface IConsentRepository
 {
     Task<ConsentRecord?> GetAsync(string bucket, string emailHash, string permission);
-    Task UpsertAsync(ConsentRecord record);
+    Task UpsertAsync(ConsentRecord record, string? actorId = null);
+    Task<PagedResult<ConsentAuditEntry>> GetAuditAsync(string? bucket, string? emailHash, int page, int pageSize, CancellationToken ct = default);
 
     // Admin queries
     Task<IReadOnlyList<BucketInfo>> GetBucketsAsync();

--- a/Source/Beacon.Core/Services/IConsentService.cs
+++ b/Source/Beacon.Core/Services/IConsentService.cs
@@ -5,8 +5,8 @@ namespace Beacon.Core.Services;
 public interface IConsentService
 {
     Task<ConsentStatus> CheckAsync(string bucket, string email, string permission);
-    Task ProcessOptOutAsync(string bucket, string email, string[] permissions, string token, ConsentSource source);
-    Task OverrideAsync(string bucket, string email, string permission, ConsentStatus status, string? customFieldsJson = null);
+    Task ProcessOptOutAsync(string bucket, string email, string[] permissions, string token, ConsentSource source, string? ipAddress = null);
+    Task OverrideAsync(string bucket, string email, string permission, ConsentStatus status, string? customFieldsJson = null, string? actorId = null);
 
     /// <summary>
     /// Ensures a consent record exists. Creates with the specified status if not found,

--- a/Source/Beacon.Storage/BeaconDbContext.cs
+++ b/Source/Beacon.Storage/BeaconDbContext.cs
@@ -21,6 +21,7 @@ public class BeaconDbContext : DbContext
     public DbSet<BucketOptions> BucketOptions => Set<BucketOptions>();
     public DbSet<User> Users => Set<User>();
     public DbSet<WorkflowTask> WorkflowTasks => Set<WorkflowTask>();
+    public DbSet<ConsentAuditEntry> ConsentAuditEntries => Set<ConsentAuditEntry>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -186,6 +187,19 @@ public class BeaconDbContext : DbContext
             entity.Property(e => e.Status).HasConversion<string>().HasMaxLength(20).IsRequired();
             entity.Property(e => e.TriggeredBy).HasConversion<string>().HasMaxLength(20).IsRequired();
             entity.HasIndex(e => e.ScheduledAt);
+        });
+
+        modelBuilder.Entity<ConsentAuditEntry>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Bucket).HasMaxLength(100).IsRequired();
+            entity.Property(e => e.EmailHash).HasMaxLength(64).IsRequired();
+            entity.Property(e => e.Permission).HasMaxLength(100).IsRequired();
+            entity.Property(e => e.ActorId).HasMaxLength(100);
+            entity.Property(e => e.IpAddress).HasMaxLength(45);
+            entity.HasIndex(e => e.EmailHash);
+            entity.HasIndex(e => e.ChangedAt);
+            entity.HasIndex(e => new { e.Bucket, e.ChangedAt });
         });
 
         modelBuilder.Entity<SubmissionForm>(entity =>

--- a/Source/Beacon.Storage/ConsentAuditBackfillService.cs
+++ b/Source/Beacon.Storage/ConsentAuditBackfillService.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -23,14 +24,24 @@ public sealed class ConsentAuditBackfillService : BackgroundService
         using var scope = _scopeFactory.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<BeaconDbContext>();
 
+        using var tx = await db.Database.BeginTransactionAsync(IsolationLevel.Serializable, stoppingToken);
+
         var auditCount = await db.Database
             .SqlQueryRaw<int>("SELECT COUNT(*) AS Value FROM ConsentAuditEntries")
             .SingleAsync(stoppingToken);
 
-        if (auditCount > 0) return;
+        if (auditCount > 0)
+        {
+            await tx.RollbackAsync(stoppingToken);
+            return;
+        }
 
         var consentCount = await db.ConsentRecords.CountAsync(stoppingToken);
-        if (consentCount == 0) return;
+        if (consentCount == 0)
+        {
+            await tx.RollbackAsync(stoppingToken);
+            return;
+        }
 
         _logger.LogInformation(
             "Audit backfill: populating {Count} consent records into ConsentAuditEntries",
@@ -53,6 +64,7 @@ public sealed class ConsentAuditBackfillService : BackgroundService
             FROM ConsentRecords
             """, stoppingToken);
 
+        await tx.CommitAsync(stoppingToken);
         _logger.LogInformation("Audit backfill: complete");
     }
 }

--- a/Source/Beacon.Storage/ConsentAuditBackfillService.cs
+++ b/Source/Beacon.Storage/ConsentAuditBackfillService.cs
@@ -1,0 +1,58 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Beacon.Storage;
+
+public sealed class ConsentAuditBackfillService : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<ConsentAuditBackfillService> _logger;
+
+    public ConsentAuditBackfillService(
+        IServiceScopeFactory scopeFactory,
+        ILogger<ConsentAuditBackfillService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<BeaconDbContext>();
+
+        var auditCount = await db.Database
+            .SqlQueryRaw<int>("SELECT COUNT(*) AS Value FROM ConsentAuditEntries")
+            .SingleAsync(stoppingToken);
+
+        if (auditCount > 0) return;
+
+        var consentCount = await db.ConsentRecords.CountAsync(stoppingToken);
+        if (consentCount == 0) return;
+
+        _logger.LogInformation(
+            "Audit backfill: populating {Count} consent records into ConsentAuditEntries",
+            consentCount);
+
+        await db.Database.ExecuteSqlRawAsync("""
+            INSERT INTO ConsentAuditEntries
+                (Id, Bucket, EmailHash, Permission, OldStatus, NewStatus, Source, ActorId, ChangedAt, IpAddress)
+            SELECT
+                lower(
+                    hex(randomblob(4)) || '-' ||
+                    hex(randomblob(2)) || '-4' ||
+                    substr(hex(randomblob(2)), 2) || '-' ||
+                    substr('89ab', (abs(random()) % 4) + 1, 1) ||
+                    substr(hex(randomblob(2)), 2) || '-' ||
+                    hex(randomblob(6))
+                ),
+                Bucket, EmailHash, Permission,
+                NULL, Status, Source, NULL, ChangedAt, IpAddress
+            FROM ConsentRecords
+            """, stoppingToken);
+
+        _logger.LogInformation("Audit backfill: complete");
+    }
+}

--- a/Source/Beacon.Storage/ConsentRepository.cs
+++ b/Source/Beacon.Storage/ConsentRepository.cs
@@ -20,13 +20,15 @@ public sealed class ConsentRepository : IConsentRepository
             .FirstOrDefaultAsync(r => r.Bucket == bucket && r.EmailHash == emailHash && r.Permission == permission);
     }
 
-    public async Task UpsertAsync(ConsentRecord record)
+    public async Task UpsertAsync(ConsentRecord record, string? actorId = null)
     {
         var existing = await _context.ConsentRecords
-            .FirstOrDefaultAsync(r 
-                => r.Bucket == record.Bucket 
-                && r.EmailHash == record.EmailHash 
+            .FirstOrDefaultAsync(r
+                => r.Bucket == record.Bucket
+                && r.EmailHash == record.EmailHash
                 && r.Permission == record.Permission);
+
+        ConsentStatus? oldStatus = existing?.Status;
 
         if (existing is null)
         {
@@ -34,7 +36,6 @@ public sealed class ConsentRepository : IConsentRepository
         }
         else
         {
-            // Update only mutable properties on the tracked entity
             existing.Status = record.Status;
             existing.Source = record.Source;
             existing.ChangedAt = record.ChangedAt;
@@ -45,10 +46,51 @@ public sealed class ConsentRepository : IConsentRepository
             {
                 existing.CustomFields = record.CustomFields;
             }
-            // EF Core tracks changes automatically, no need for Update()
+        }
+
+        if (oldStatus != record.Status)
+        {
+            _context.ConsentAuditEntries.Add(new ConsentAuditEntry
+            {
+                Id = Guid.NewGuid(),
+                Bucket = record.Bucket,
+                EmailHash = record.EmailHash,
+                Permission = record.Permission,
+                OldStatus = oldStatus,
+                NewStatus = record.Status,
+                Source = record.Source,
+                ActorId = actorId,
+                ChangedAt = record.ChangedAt,
+                IpAddress = record.IpAddress
+            });
         }
 
         await _context.SaveChangesAsync();
+    }
+
+    public async Task<PagedResult<ConsentAuditEntry>> GetAuditAsync(
+        string? bucket, string? emailHash, int page, int pageSize, CancellationToken ct = default)
+    {
+        var query = _context.ConsentAuditEntries.AsQueryable();
+        if (!string.IsNullOrWhiteSpace(bucket))
+            query = query.Where(e => e.Bucket == bucket);
+        if (!string.IsNullOrWhiteSpace(emailHash))
+            query = query.Where(e => e.EmailHash == emailHash);
+
+        var total = await query.CountAsync(ct);
+        var records = await query
+            .OrderByDescending(e => e.ChangedAt)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(ct);
+
+        return new PagedResult<ConsentAuditEntry>
+        {
+            Records = records,
+            Total = total,
+            Page = page,
+            PageSize = pageSize
+        };
     }
 
     public async Task<IReadOnlyList<BucketInfo>> GetBucketsAsync()
@@ -398,10 +440,17 @@ public sealed class ConsentRepository : IConsentRepository
 
     public async Task<int> AnonymiseIpAddressesAsync(DateTime cutoff, CancellationToken ct = default)
     {
-        return await _context.ConsentRecords
+        var records = await _context.ConsentRecords
             .Where(r => r.IpAddress != null && r.ChangedAt < cutoff)
             .ExecuteUpdateAsync(s => s
                 .SetProperty(r => r.IpAddress, (string?)null), ct);
+
+        var audit = await _context.ConsentAuditEntries
+            .Where(e => e.IpAddress != null && e.ChangedAt < cutoff)
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(e => e.IpAddress, (string?)null), ct);
+
+        return records + audit;
     }
 
     public async Task<int> PurgePendingConfirmationAsync(DateTime cutoff, CancellationToken ct = default)
@@ -421,8 +470,13 @@ public sealed class ConsentRepository : IConsentRepository
 
     public async Task<int> CountIpAddressesToAnonymiseAsync(DateTime cutoff, CancellationToken ct = default)
     {
-        return await _context.ConsentRecords
+        var records = await _context.ConsentRecords
             .CountAsync(r => r.IpAddress != null && r.ChangedAt < cutoff, ct);
+
+        var audit = await _context.ConsentAuditEntries
+            .CountAsync(e => e.IpAddress != null && e.ChangedAt < cutoff, ct);
+
+        return records + audit;
     }
 
     public async Task<int> CountPendingConfirmationToPurgeAsync(DateTime cutoff, CancellationToken ct = default)

--- a/Source/Beacon.Storage/DataPolicyWorker.cs
+++ b/Source/Beacon.Storage/DataPolicyWorker.cs
@@ -54,7 +54,7 @@ public sealed class DataPolicyWorker : BackgroundService
         }
         catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested) { }
 
-        _logger.LogInformation("Data policy worker stopped");
+        _logger.LogDebug("Data policy worker stopped");
     }
 
     /// <summary>Returns true if woken by a trigger signal, false if the cron delay elapsed.</summary>

--- a/Source/Beacon.Storage/DatabaseMigrator.cs
+++ b/Source/Beacon.Storage/DatabaseMigrator.cs
@@ -19,6 +19,7 @@ public static class DatabaseMigrator
         MigrateBucketOptions(db);
         MigrateUsers(db);
         MigrateWorkflowTasks(db);
+        MigrateConsentAuditEntries(db);
     }
 
     private static HashSet<string> GetColumns(BeaconDbContext db, string table)
@@ -231,6 +232,34 @@ public static class DatabaseMigrator
                 )
                 """);
             db.Database.ExecuteSqlRaw("CREATE INDEX IX_WorkflowTasks_ScheduledAt ON WorkflowTasks (ScheduledAt)");
+        }
+    }
+
+    private static void MigrateConsentAuditEntries(BeaconDbContext db)
+    {
+        if (!TableExists(db, "ConsentAuditEntries"))
+        {
+            db.Database.ExecuteSqlRaw("""
+                CREATE TABLE ConsentAuditEntries (
+                    Id TEXT NOT NULL PRIMARY KEY,
+                    Bucket TEXT NOT NULL,
+                    EmailHash TEXT NOT NULL,
+                    Permission TEXT NOT NULL,
+                    OldStatus INTEGER NULL,
+                    NewStatus INTEGER NOT NULL,
+                    Source INTEGER NOT NULL,
+                    ActorId TEXT NULL,
+                    ChangedAt TEXT NOT NULL,
+                    IpAddress TEXT NULL
+                )
+                """);
+            db.Database.ExecuteSqlRaw(
+                "CREATE INDEX IX_ConsentAuditEntries_EmailHash ON ConsentAuditEntries (EmailHash)");
+            db.Database.ExecuteSqlRaw(
+                "CREATE INDEX IX_ConsentAuditEntries_ChangedAt ON ConsentAuditEntries (ChangedAt)");
+            db.Database.ExecuteSqlRaw(
+                "CREATE INDEX IX_ConsentAuditEntries_Bucket_ChangedAt ON ConsentAuditEntries (Bucket, ChangedAt)");
+
         }
     }
 

--- a/Source/Beacon.Storage/EmailQueueWorker.cs
+++ b/Source/Beacon.Storage/EmailQueueWorker.cs
@@ -53,7 +53,7 @@ public sealed class EmailQueueWorker : BackgroundService
         }
         catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested) { }
 
-        _logger.LogInformation("Email queue worker stopped");
+        _logger.LogDebug("Email queue worker stopped");
     }
 
     /// <summary>

--- a/Source/Beacon.Storage/StorageConfiguration.cs
+++ b/Source/Beacon.Storage/StorageConfiguration.cs
@@ -36,6 +36,7 @@ public static class StorageConfiguration
         services.AddScoped<IEmailQueueRepository, EmailQueueRepository>();
         services.AddScoped<IBucketOptionsRepository, BucketOptionsRepository>();
         services.AddScoped<IEmailSenderService, EmailSenderService>();
+
         services.AddSingleton<EmailDispatchTrigger>();
         services.AddHostedService<EmailQueueWorker>();
 
@@ -43,6 +44,8 @@ public static class StorageConfiguration
         services.AddScoped<IWorkflowTaskRepository, WorkflowTaskRepository>();
         services.AddScoped<DataPolicyService>();
         services.AddHostedService<DataPolicyWorker>();
+        
+        services.AddHostedService<ConsentAuditBackfillService>();
 
         return services;
     }

--- a/Source/Beacon.Tests/ConsentAuditRepositoryTests.cs
+++ b/Source/Beacon.Tests/ConsentAuditRepositoryTests.cs
@@ -1,0 +1,147 @@
+using Beacon.Core.Models;
+using Beacon.Core.Services;
+using Beacon.Storage;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Beacon.Tests;
+
+public class ConsentAuditRepositoryTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly BeaconDbContext _db;
+    private readonly ConsentRepository _repository;
+
+    public ConsentAuditRepositoryTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        var options = new DbContextOptionsBuilder<BeaconDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+        _db = new BeaconDbContext(options);
+        _db.Database.EnsureCreated();
+        _repository = new ConsentRepository(_db);
+    }
+
+    public void Dispose()
+    {
+        _db.Dispose();
+        _connection.Dispose();
+    }
+
+    [Fact]
+    public async Task UpsertAsync_Insert_CreatesAuditEntryWithNullOldStatus()
+    {
+        var record = MakeRecord("bucket-a", "hash1", "newsletter", ConsentStatus.OptedIn);
+
+        await _repository.UpsertAsync(record);
+        _db.ChangeTracker.Clear();
+
+        var result = await _repository.GetAuditAsync(null, null, 1, 10);
+        Assert.Equal(1, result.Total);
+        var entry = result.Records[0];
+        Assert.Null(entry.OldStatus);
+        Assert.Equal(ConsentStatus.OptedIn, entry.NewStatus);
+        Assert.Equal("bucket-a", entry.Bucket);
+        Assert.Equal("hash1", entry.EmailHash);
+        Assert.Equal("newsletter", entry.Permission);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_StatusChange_CreatesSecondAuditEntry()
+    {
+        await _repository.UpsertAsync(MakeRecord("bucket-a", "hash1", "newsletter", ConsentStatus.OptedIn));
+        _db.ChangeTracker.Clear();
+
+        await _repository.UpsertAsync(MakeRecord("bucket-a", "hash1", "newsletter", ConsentStatus.OptedOut));
+        _db.ChangeTracker.Clear();
+
+        var result = await _repository.GetAuditAsync(null, null, 1, 10);
+        Assert.Equal(2, result.Total);
+
+        var latest = result.Records[0];
+        Assert.Equal(ConsentStatus.OptedIn, latest.OldStatus);
+        Assert.Equal(ConsentStatus.OptedOut, latest.NewStatus);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_SameStatus_NoNewAuditEntry()
+    {
+        var record = MakeRecord("bucket-a", "hash1", "newsletter", ConsentStatus.OptedIn);
+        await _repository.UpsertAsync(record);
+
+        await _repository.UpsertAsync(record);
+        _db.ChangeTracker.Clear();
+
+        var result = await _repository.GetAuditAsync(null, null, 1, 10);
+        Assert.Equal(1, result.Total);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_WithActorId_StoresActorInAuditEntry()
+    {
+        var record = MakeRecord("bucket-a", "hash1", "newsletter", ConsentStatus.OptedIn);
+
+        await _repository.UpsertAsync(record, "alice");
+        _db.ChangeTracker.Clear();
+
+        var result = await _repository.GetAuditAsync(null, null, 1, 10);
+        Assert.Equal("alice", result.Records[0].ActorId);
+    }
+
+    [Fact]
+    public async Task GetAuditAsync_Pagination_ReturnsCorrectPage()
+    {
+        await _repository.UpsertAsync(MakeRecord("bucket-a", "hash1", "newsletter", ConsentStatus.OptedIn));
+        await _repository.UpsertAsync(MakeRecord("bucket-a", "hash2", "newsletter", ConsentStatus.OptedIn));
+        await _repository.UpsertAsync(MakeRecord("bucket-a", "hash3", "newsletter", ConsentStatus.OptedIn));
+        _db.ChangeTracker.Clear();
+
+        var page1 = await _repository.GetAuditAsync(null, null, 1, 2);
+        var page2 = await _repository.GetAuditAsync(null, null, 2, 2);
+
+        Assert.Equal(3, page1.Total);
+        Assert.Equal(2, page1.Records.Count);
+        Assert.Single(page2.Records);
+    }
+
+    [Fact]
+    public async Task GetAuditAsync_BucketFilter_ReturnsOnlyMatchingBucket()
+    {
+        await _repository.UpsertAsync(MakeRecord("bucket-a", "hash1", "newsletter", ConsentStatus.OptedIn));
+        await _repository.UpsertAsync(MakeRecord("bucket-b", "hash1", "newsletter", ConsentStatus.OptedIn));
+        _db.ChangeTracker.Clear();
+
+        var result = await _repository.GetAuditAsync("bucket-a", null, 1, 10);
+
+        Assert.Equal(1, result.Total);
+        Assert.Equal("bucket-a", result.Records[0].Bucket);
+    }
+
+    [Fact]
+    public async Task GetAuditAsync_EmailHashFilter_ReturnsOnlyMatchingIdentity()
+    {
+        await _repository.UpsertAsync(MakeRecord("bucket-a", "hash1", "newsletter", ConsentStatus.OptedIn));
+        await _repository.UpsertAsync(MakeRecord("bucket-a", "hash2", "newsletter", ConsentStatus.OptedIn));
+        _db.ChangeTracker.Clear();
+
+        var result = await _repository.GetAuditAsync(null, "hash2", 1, 10);
+
+        Assert.Equal(1, result.Total);
+        Assert.Equal("hash2", result.Records[0].EmailHash);
+    }
+
+    private static ConsentRecord MakeRecord(string bucket, string emailHash, string permission, ConsentStatus status) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Bucket = bucket,
+            EmailHash = emailHash,
+            Permission = permission,
+            Status = status,
+            Source = ConsentSource.Admin,
+            ChangedAt = DateTime.UtcNow
+        };
+}

--- a/Source/Beacon.Tests/Fakes/InMemoryConsentRepository.cs
+++ b/Source/Beacon.Tests/Fakes/InMemoryConsentRepository.cs
@@ -14,12 +14,17 @@ internal sealed class InMemoryConsentRepository : IConsentRepository
         return Task.FromResult(record);
     }
 
-    public Task UpsertAsync(ConsentRecord record)
+    public Task UpsertAsync(ConsentRecord record, string? actorId = null)
     {
         var key = $"{record.Bucket}:{record.EmailHash}:{record.Permission}";
         _records[key] = record;
         return Task.CompletedTask;
     }
+
+    public Task<PagedResult<ConsentAuditEntry>> GetAuditAsync(
+        string? bucket, string? emailHash, int page, int pageSize, CancellationToken ct = default)
+        => Task.FromResult(new PagedResult<ConsentAuditEntry>
+            { Records = [], Total = 0, Page = page, PageSize = pageSize });
 
     public Task<IReadOnlyList<BucketInfo>> GetBucketsAsync()
     {

--- a/Source/Beacon.Tests/SubmissionFormServiceTests.cs
+++ b/Source/Beacon.Tests/SubmissionFormServiceTests.cs
@@ -699,12 +699,17 @@ public class SubmissionFormServiceTests
             return Task.FromResult(record);
         }
 
-        public Task UpsertAsync(ConsentRecord record)
+        public Task UpsertAsync(ConsentRecord record, string? actorId = null)
         {
             var key = $"{record.Bucket}:{record.EmailHash}:{record.Permission}";
             _records[key] = record;
             return Task.CompletedTask;
         }
+
+        public Task<PagedResult<ConsentAuditEntry>> GetAuditAsync(
+            string? bucket, string? emailHash, int page, int pageSize, CancellationToken ct = default)
+            => Task.FromResult(new PagedResult<ConsentAuditEntry>
+                { Records = [], Total = 0, Page = page, PageSize = pageSize });
 
         public Task<IReadOnlyList<BucketInfo>> GetBucketsAsync()
         {

--- a/Source/Beacon/Api/AdminEndpoints.cs
+++ b/Source/Beacon/Api/AdminEndpoints.cs
@@ -157,9 +157,14 @@ public static class AdminEndpoints
         routes.MapPost("/api/admin/data-policies/tasks/{id}/reject", RejectWorkflowTask)
             .RequireAuthorization("Admin")
             .ExcludeFromDescription();
+
+        routes.MapGet("/api/admin/audit", GetAuditLog)
+            .RequireAuthorization()
+            .ExcludeFromDescription();
     }
 
     private static async Task<IResult> OverrideConsent(
+        HttpContext context,
         [FromBody] OverrideConsentRequest request,
         [FromServices] IConsentService consentService,
         [FromServices] IConsentRepository consentRepository,
@@ -210,9 +215,11 @@ public static class AdminEndpoints
             ? JsonSerializer.Serialize(request.CustomFields)
             : null;
 
+        var actorId = context.User.Identity?.Name;
+
         try
         {
-            await consentService.OverrideAsync(request.Bucket, request.Email, request.Permission, status, customFieldsJson);
+            await consentService.OverrideAsync(request.Bucket, request.Email, request.Permission, status, customFieldsJson, actorId);
 
             await TriggerWebhookSafe(webhookService, consentRepository, request.Bucket, request.Email, emailHash, customFieldsJson);
             await notifications.PublishConsentUpdateAsync(new ConsentUpdateNotification(request.Bucket));
@@ -238,6 +245,7 @@ public static class AdminEndpoints
     }
 
     private static async Task<IResult> BatchOverrideConsent(
+        HttpContext httpContext,
         string bucket,
         [FromBody] BatchOverrideRequest request,
         [FromServices] IConsentService consentService,
@@ -277,6 +285,8 @@ public static class AdminEndpoints
             ? JsonSerializer.Serialize(request.CustomFields)
             : null;
 
+        var actorId = httpContext.User.Identity?.Name;
+
         try
         {
             using var transaction = await consentService.BeginTransactionAsync();
@@ -288,7 +298,7 @@ public static class AdminEndpoints
                     return Results.BadRequest(new { error = $"Invalid status '{status}' for permission '{permission}'" });
                 }
 
-                await consentService.OverrideAsync(normalizedBucket, request.Email, permission, consentStatus, customFieldsJson);
+                await consentService.OverrideAsync(normalizedBucket, request.Email, permission, consentStatus, customFieldsJson, actorId);
             }
 
             await consentService.CommitTransactionAsync();
@@ -372,6 +382,7 @@ public static class AdminEndpoints
         var config = configService.Get();
         var emailProviderNormalized = config.EmailProvider?.Trim().ToLowerInvariant() ?? string.Empty;
         var responses = new List<GenerateTokenResponse>(requests.Count);
+        var actorId = context.User.Identity?.Name;
 
         try
         {
@@ -429,7 +440,7 @@ public static class AdminEndpoints
                     else
                     {
                         // Always upsert (insert or update)
-                        await consentService.OverrideAsync(request.Bucket, request.Email, permission, status, customFieldsJson);
+                        await consentService.OverrideAsync(request.Bucket, request.Email, permission, status, customFieldsJson, actorId);
                         hasChanges = true;
                     }
                 }
@@ -1406,6 +1417,43 @@ public static class AdminEndpoints
             TaskOperationOutcome.InvalidStatus => Results.BadRequest("Task is not pending approval."),
             _ => Results.Ok(result.Task)
         };
+    }
+
+    private static async Task<IResult> GetAuditLog(
+        [FromQuery] string? bucket,
+        [FromQuery] string? identity,
+        [FromQuery] int page = 1,
+        [FromQuery] int size = 25,
+        [FromServices] IConsentRepository repository = null!,
+        CancellationToken ct = default)
+    {
+        if (page < 1) page = 1;
+        size = Math.Clamp(size, 1, 100);
+        var normalizedBucket = string.IsNullOrWhiteSpace(bucket) ? null : bucket.Trim().ToLowerInvariant();
+        var normalizedHash = string.IsNullOrWhiteSpace(identity) ? null : identity.Trim().ToLowerInvariant();
+
+        var result = await repository.GetAuditAsync(normalizedBucket, normalizedHash, page, size, ct);
+
+        return Results.Ok(new
+        {
+            records = result.Records.Select(e => new
+            {
+                id = e.Id,
+                bucket = e.Bucket,
+                emailHash = e.EmailHash,
+                displayId = e.EmailHash[..Math.Min(16, e.EmailHash.Length)] + "...",
+                permission = e.Permission,
+                oldStatus = e.OldStatus?.ToString(),
+                newStatus = e.NewStatus.ToString(),
+                source = e.Source.ToString(),
+                actorId = e.ActorId,
+                changedAt = e.ChangedAt,
+                ipAddress = e.IpAddress
+            }),
+            total = result.Total,
+            page = result.Page,
+            pageSize = result.PageSize
+        });
     }
 
     private static bool IsPrivateOrReserved(IPAddress address)

--- a/Source/Beacon/Api/AdminEndpoints.cs
+++ b/Source/Beacon/Api/AdminEndpoints.cs
@@ -1421,7 +1421,7 @@ public static class AdminEndpoints
 
     private static async Task<IResult> GetAuditLog(
         [FromQuery] string? bucket,
-        [FromQuery] string? identity,
+        [FromQuery] string? emailHash,
         [FromQuery] int page = 1,
         [FromQuery] int size = 25,
         [FromServices] IConsentRepository repository = null!,
@@ -1430,7 +1430,7 @@ public static class AdminEndpoints
         if (page < 1) page = 1;
         size = Math.Clamp(size, 1, 100);
         var normalizedBucket = string.IsNullOrWhiteSpace(bucket) ? null : bucket.Trim().ToLowerInvariant();
-        var normalizedHash = string.IsNullOrWhiteSpace(identity) ? null : identity.Trim().ToLowerInvariant();
+        var normalizedHash = string.IsNullOrWhiteSpace(emailHash) ? null : emailHash.Trim().ToLowerInvariant();
 
         var result = await repository.GetAuditAsync(normalizedBucket, normalizedHash, page, size, ct);
 

--- a/Source/Beacon/Api/ConsentEndpoints.cs
+++ b/Source/Beacon/Api/ConsentEndpoints.cs
@@ -152,6 +152,7 @@ public static class ConsentEndpoints
 
         var form = await context.Request.ReadFormAsync();
         var action = form["action"].ToString();
+        var ipAddress = context.Connection.RemoteIpAddress?.ToString();
 
         try
         {
@@ -168,7 +169,8 @@ public static class ConsentEndpoints
                     result.Payload.Email,
                     validPermissions,
                     token,
-                    ConsentSource.Url);
+                    ConsentSource.Url,
+                    ipAddress);
 
                 await consentService.CommitTransactionAsync();
 
@@ -202,7 +204,8 @@ public static class ConsentEndpoints
                         result.Payload.Email,
                         [permission],
                         token,
-                        ConsentSource.Url);
+                        ConsentSource.Url,
+                        ipAddress);
                     optedOut.Add(permission);
                 }
                 else

--- a/Source/Beacon/Program.cs
+++ b/Source/Beacon/Program.cs
@@ -111,6 +111,9 @@ try
     var normalizedSigningKey = NormalizeKey(signingKey, 32);
     var normalizedEncryptionKey = NormalizeKey(encryptionKey, 32);
 
+    builder.Services.Configure<Microsoft.Extensions.Hosting.HostOptions>(o =>
+        o.ShutdownTimeout = TimeSpan.FromSeconds(30));
+
     // Service Registration
     builder.Services.AddBeaconStorage(databaseProvider, connectionString);
 

--- a/Source/Beacon/wwwroot/admin.html
+++ b/Source/Beacon/wwwroot/admin.html
@@ -156,6 +156,9 @@
       <a href="#" class="nav-item" data-view="submissions" onclick="showView('submissions')">
         Submission Forms
       </a>
+      <a href="#" class="nav-item" data-view="audit" onclick="showView('audit')">
+        Audit
+      </a>
     </div>
 
     <div class="sidebar-footer" style="display: flex; flex-direction: column; gap: 0.75rem; padding-top: 1rem; border-top: 1px solid hsl(var(--border));">
@@ -916,6 +919,60 @@
           <div style="display:flex;gap:0.5rem">
             <button class="btn btn-outline" id="workflowPrevBtn" onclick="changeWorkflowPage(-1)">Previous</button>
             <button class="btn btn-outline" id="workflowNextBtn" onclick="changeWorkflowPage(1)">Next</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Audit View -->
+    <div id="view-audit" class="view">
+      <section class="header-container" style="flex-shrink:0">
+        <div>
+          <h1 class="select-none">Audit</h1>
+          <span class="status-badge select-none">Consent History</span>
+        </div>
+        <div class="bucket-actions">
+          <span class="tooltip-wrapper">
+            <button class="btn btn-outline" onclick="loadAudit()">Refresh</button>
+            <span class="tooltip tooltip-right">Reload audit log</span>
+          </span>
+        </div>
+      </section>
+      <div class="table-wrapper">
+        <div class="scroll-area">
+          <table>
+            <thead>
+              <tr id="auditTableHead">
+                <th>Timestamp</th>
+                <th>Identity</th>
+                <th>Bucket</th>
+                <th>Permission</th>
+                <th>Change</th>
+                <th>Source</th>
+                <th>Actor</th>
+                <th>IP</th>
+              </tr>
+            </thead>
+            <tbody id="auditBody"></tbody>
+          </table>
+        </div>
+        <div class="pagination-container">
+          <div class="pagination-settings">
+            <div class="page-size-selector">
+              <span>Show</span>
+              <select class="page-size-input" id="auditPageSizeSelect" onchange="updateAuditPageSize()">
+                <option value="10">10</option>
+                <option value="25" selected>25</option>
+                <option value="50">50</option>
+                <option value="100">100</option>
+              </select>
+              <span>per page</span>
+            </div>
+            <div class="pagination-info" id="auditPaginationInfo"></div>
+          </div>
+          <div style="display:flex;gap:0.5rem">
+            <button class="btn btn-outline" id="auditPrevBtn" onclick="changeAuditPage(-1)">Previous</button>
+            <button class="btn btn-outline" id="auditNextBtn" onclick="changeAuditPage(1)">Next</button>
           </div>
         </div>
       </div>

--- a/Source/Beacon/wwwroot/css/site.css
+++ b/Source/Beacon/wwwroot/css/site.css
@@ -703,6 +703,8 @@ thead { position: sticky; top: 0; background: hsl(var(--background)); z-index: 5
 th { text-align: left; padding: 0.875rem 1rem; color: hsl(var(--muted-foreground)); font-weight: 500; white-space: nowrap; }
 .sortable { cursor: pointer; user-select: none; }
 .sortable:hover { color: hsl(var(--foreground)); }
+.col-link { cursor: pointer; }
+.col-link:hover { text-decoration: underline; text-decoration-style: dotted; text-underline-offset: 3px; }
 .sortable .sort-icon { display: inline-block; margin-left: 0.25rem; opacity: 0.3; }
 .sortable.asc .sort-icon, .sortable.desc .sort-icon { opacity: 1; }
 .sortable.desc .sort-icon { transform: rotate(180deg); }

--- a/Source/Beacon/wwwroot/css/site.css
+++ b/Source/Beacon/wwwroot/css/site.css
@@ -61,6 +61,7 @@ body {
 }
 
 .select-none { user-select: none; }
+.muted { color: hsl(var(--muted-foreground)); }
 
 /* Toast Notifications */
 .toast-container {
@@ -499,6 +500,31 @@ h1 { font-size: 1.75rem; font-weight: 700; letter-spacing: -0.02em; }
 .status-badge.rejected {
     background: hsl(var(--muted));
     color: hsl(var(--muted-foreground) / 0.5);
+}
+
+/* Inline status chip — same tokens as status-badge but no block margin */
+.status-chip {
+    display: inline-flex;
+    font-size: 0.7rem;
+    font-weight: 500;
+    padding: 0.15rem 0.45rem;
+    border-radius: 4px;
+    white-space: nowrap;
+    vertical-align: middle;
+    background: hsl(var(--muted));
+    color: hsl(var(--muted-foreground));
+}
+.status-chip.opted-in {
+    background: hsl(var(--success) / 0.12);
+    color: hsl(var(--success));
+}
+.status-chip.opted-out {
+    background: hsl(var(--destructive) / 0.1);
+    color: hsl(var(--destructive));
+}
+.status-chip.pending {
+    background: hsl(var(--muted));
+    color: hsl(var(--muted-foreground));
 }
 
 .bucket-actions { display: flex; gap: 0.75rem; align-items: center; }

--- a/Source/Beacon/wwwroot/js/admin.js
+++ b/Source/Beacon/wwwroot/js/admin.js
@@ -2,6 +2,9 @@
     const MAX_SIDEBAR_BUCKETS = 10;
     let currentBucket = '';
     let currentView = 'overview';
+    let auditCurrentPage = 1, auditPageSize = 25, auditTotalRecords = 0;
+    let auditFilterBucket = null, auditFilterIdentity = null;
+    let _auditClickTimer = null;
     let currentBucketArchived = false;
     let currentPage = 1;
     let pageSize = 10;
@@ -226,6 +229,11 @@
         showSettingsSection(section, false);
       } else if (view === 'workflow') {
         showView('workflow', false);
+      } else if (view === 'audit') {
+        auditFilterBucket = params.get('bucket') || null;
+        auditFilterIdentity = params.get('identity') || null;
+        auditCurrentPage = parseInt(params.get('page') || '1');
+        showView('audit', false);
       } else {
         showView('overview', false);
       }
@@ -649,6 +657,7 @@
       if (view === 'new-token') document.getElementById('tokenLanguage').value = appSettings.uiLanguage || 'en';
       if (view === 'settings') loadSettings();
       if (view === 'workflow') loadWorkflowPage();
+      if (view === 'audit') loadAudit();
       if (view === 'subscriptions') {
         loadIdentities(pushState);
       }
@@ -763,6 +772,7 @@
                 <div class="dropdown-menu" id="rowMenu-sub-${idx}">
                   <button class="dropdown-item" onclick="showBucket('${sanitize(s.bucket)}')">View Bucket</button>
                   <button class="dropdown-item" onclick="openEditFromSubscription('${sanitize(s.bucket)}', '${permKeys}', '${recordData}')">Edit Permissions</button>
+                  <button class="dropdown-item" onclick="showAuditForBucketAndIdentity('${sanitize(s.bucket)}', '${sanitize(subDetailHash)}')">View Audit</button>
                 </div>
               </div>
             </td>
@@ -911,7 +921,7 @@
         const msg = subSearchQuery ? `No identities matching "${sanitize(subSearchQuery)}"` : 'No consent records found across any bucket';
         body.innerHTML = `<tr><td colspan="4" style="text-align:center;padding:3rem;color:hsl(var(--muted-foreground))">${msg}</td></tr>`;
       } else {
-        body.innerHTML = data.records.map(id => {
+        body.innerHTML = data.records.map((id, idx) => {
           const idDisplay = `<span class="tooltip-wrapper" ondblclick="event.stopPropagation();copyTextNow('${sanitize(id.emailHash)}')"><span class="email-hash">${sanitize(id.emailHash.substring(0, 16))}...</span><span class="tooltip">Double-click to copy ID</span></span>`;
           return `
             <tr style="cursor:pointer" onclick="showIdentityDetails('${sanitize(id.emailHash)}')">
@@ -921,9 +931,13 @@
               <td>
                 <div class="row-actions">
                   <span class="tooltip-wrapper">
-                    <button class="btn-actions" onclick="event.stopPropagation();showIdentityDetails('${sanitize(id.emailHash)}')">:</button>
-                    <span class="tooltip tooltip-above tooltip-right">View details</span>
+                    <button class="btn-actions" onclick="event.stopPropagation();toggleRowMenu(event, 'sid-${idx}')">:</button>
+                    <span class="tooltip tooltip-above tooltip-right">Actions</span>
                   </span>
+                  <div class="dropdown-menu" id="rowMenu-sid-${idx}">
+                    <button class="dropdown-item" onclick="showIdentityDetails('${sanitize(id.emailHash)}')">View Details</button>
+                    <button class="dropdown-item" onclick="showAuditForIdentity('${sanitize(id.emailHash)}')">View Audit</button>
+                  </div>
                 </div>
               </td>
             </tr>
@@ -1193,6 +1207,7 @@
                   <div class="dropdown-menu" id="rowMenu-${idx}">
                     <button class="dropdown-item" onclick="openEditPermissions('${recordData}')">Edit Permissions</button>
                     <button class="dropdown-item" onclick="openOptOutPage('${recordData}')">Open Consent Page <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-left:auto;flex-shrink:0"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg></button>
+                    <button class="dropdown-item" onclick="showAuditForBucketAndIdentity('${sanitize(currentBucket)}', '${sanitize(r.emailHash)}')">View Audit</button>
                   </div>
                 </div>
               </td>
@@ -1602,18 +1617,22 @@
 
     let copyClickTimer = null;
 
+    function copyLabel(text) {
+      return text.length > 24 ? text.slice(0, 16) + '…' : text;
+    }
+
     function copyText(text) {
       clearTimeout(copyClickTimer);
       copyClickTimer = setTimeout(() => {
         clipboardWrite(text);
-        notify('success', 'Copied', text);
+        notify('success', 'Copied', copyLabel(text));
       }, 250);
     }
 
     function copyTextNow(text) {
       clearTimeout(copyClickTimer);
       clipboardWrite(text);
-      notify('success', 'Copied', text);
+      notify('success', 'Copied', copyLabel(text));
     }
 
     // HELPERS
@@ -3858,6 +3877,247 @@ ${bodyStr}
     let _workflowPage = 1;
     let _workflowPageSize = 25;
     let _workflowArchivedVisible = false;
+
+    // ── Audit ──────────────────────────────────────────────────────────────
+    async function loadAudit() {
+      const params = new URLSearchParams();
+      if (auditFilterBucket) params.set('bucket', auditFilterBucket);
+      if (auditFilterIdentity) params.set('identity', auditFilterIdentity);
+      params.set('page', auditCurrentPage);
+      params.set('size', auditPageSize);
+
+      const urlParams = { view: 'audit' };
+      if (auditFilterBucket) urlParams.bucket = auditFilterBucket;
+      if (auditFilterIdentity) urlParams.identity = auditFilterIdentity;
+      if (auditCurrentPage > 1) urlParams.page = auditCurrentPage;
+      updateUrl(urlParams);
+
+      renderAuditHeader();
+
+      const tbody = document.getElementById('auditBody');
+      tbody.innerHTML = '<tr><td colspan="8" style="text-align:center;padding:3rem;color:hsl(var(--muted-foreground))">Loading…</td></tr>';
+
+      const res = await apiRequest(`/api/admin/audit?${params}`);
+      if (!res.ok) {
+        tbody.innerHTML = '<tr><td colspan="8" style="text-align:center;padding:3rem;color:hsl(var(--muted-foreground))">Failed to load audit log.</td></tr>';
+        return;
+      }
+
+      auditTotalRecords = res.data.total;
+      if (res.data.records.length === 0) {
+        const msg = (auditFilterBucket || auditFilterIdentity)
+          ? 'No audit entries match the active filter'
+          : 'No audit entries yet';
+        tbody.innerHTML = `<tr><td colspan="8" style="text-align:center;padding:3rem;color:hsl(var(--muted-foreground))">${msg}</td></tr>`;
+      } else {
+        tbody.innerHTML = res.data.records.map(renderAuditRow).join('');
+      }
+      updateAuditPagination();
+    }
+
+    function renderAuditHeader() {
+      const thead = document.getElementById('auditTableHead');
+      if (!thead) return;
+      const hasIdentity = auditFilterIdentity ? 'has-search' : '';
+      const hasBucket = auditFilterBucket ? 'has-search' : '';
+      thead.innerHTML = `
+        <th>Timestamp</th>
+        <th>
+          <div class="column-search">
+            <span>Identity</span>
+            <button class="search-trigger ${hasIdentity}" id="auditIdentitySearchTrigger" onclick="toggleAuditIdentityPopover(event)" title="Filter by identity">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
+            </button>
+            <div class="search-popover" id="auditIdentityPopover" style="min-width:260px">
+              <label>Filter by identity hash (partial)</label>
+              <input type="text" id="auditIdentityInput" placeholder="e.g., a1b2c3d4" value="${sanitize(auditFilterIdentity || '')}" onkeydown="if(event.key==='Enter')applyAuditIdentityFilter()">
+              <div class="search-actions">
+                <button class="btn btn-outline" style="padding:0.375rem 0.75rem;font-size:0.75rem" onclick="clearAuditIdentityFilter()">Clear</button>
+                <button class="btn btn-primary" style="padding:0.375rem 0.75rem;font-size:0.75rem" onclick="applyAuditIdentityFilter()">Filter</button>
+              </div>
+            </div>
+          </div>
+        </th>
+        <th>
+          <div class="column-search">
+            <span>Bucket</span>
+            <button class="search-trigger ${hasBucket}" id="auditBucketSearchTrigger" onclick="toggleAuditBucketPopover(event)" title="Filter by bucket">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
+            </button>
+            <div class="search-popover" id="auditBucketPopover" style="min-width:220px">
+              <label>Filter by bucket name</label>
+              <input type="text" id="auditBucketInput" placeholder="e.g., newsletter" value="${sanitize(auditFilterBucket || '')}" onkeydown="if(event.key==='Enter')applyAuditBucketFilter()">
+              <div class="search-actions">
+                <button class="btn btn-outline" style="padding:0.375rem 0.75rem;font-size:0.75rem" onclick="clearAuditBucketFilter()">Clear</button>
+                <button class="btn btn-primary" style="padding:0.375rem 0.75rem;font-size:0.75rem" onclick="applyAuditBucketFilter()">Filter</button>
+              </div>
+            </div>
+          </div>
+        </th>
+        <th>Permission</th>
+        <th>Change</th>
+        <th>Source</th>
+        <th>Actor</th>
+        <th>IP</th>
+      `;
+    }
+
+    function toggleAuditIdentityPopover(event) {
+      event.stopPropagation();
+      const popover = document.getElementById('auditIdentityPopover');
+      const trigger = document.getElementById('auditIdentitySearchTrigger');
+      const isOpen = popover?.classList.contains('open');
+      document.querySelectorAll('.search-popover.open').forEach(p => p.classList.remove('open'));
+      document.querySelectorAll('.search-trigger.active').forEach(t => t.classList.remove('active'));
+      if (!isOpen) {
+        popover?.classList.add('open');
+        trigger?.classList.add('active');
+        setTimeout(() => document.getElementById('auditIdentityInput')?.focus(), 50);
+      }
+    }
+
+    function toggleAuditBucketPopover(event) {
+      event.stopPropagation();
+      const popover = document.getElementById('auditBucketPopover');
+      const trigger = document.getElementById('auditBucketSearchTrigger');
+      const isOpen = popover?.classList.contains('open');
+      document.querySelectorAll('.search-popover.open').forEach(p => p.classList.remove('open'));
+      document.querySelectorAll('.search-trigger.active').forEach(t => t.classList.remove('active'));
+      if (!isOpen) {
+        popover?.classList.add('open');
+        trigger?.classList.add('active');
+        setTimeout(() => document.getElementById('auditBucketInput')?.focus(), 50);
+      }
+    }
+
+    function applyAuditIdentityFilter() {
+      const val = document.getElementById('auditIdentityInput')?.value.trim();
+      auditFilterIdentity = val || null;
+      auditCurrentPage = 1;
+      document.getElementById('auditIdentityPopover')?.classList.remove('open');
+      document.getElementById('auditIdentitySearchTrigger')?.classList.remove('active');
+      loadAudit();
+    }
+
+    function applyAuditBucketFilter() {
+      const val = document.getElementById('auditBucketInput')?.value.trim();
+      auditFilterBucket = val || null;
+      auditCurrentPage = 1;
+      document.getElementById('auditBucketPopover')?.classList.remove('open');
+      document.getElementById('auditBucketSearchTrigger')?.classList.remove('active');
+      loadAudit();
+    }
+
+    function clearAuditIdentityFilter() {
+      auditFilterIdentity = null;
+      auditCurrentPage = 1;
+      document.getElementById('auditIdentityPopover')?.classList.remove('open');
+      document.getElementById('auditIdentitySearchTrigger')?.classList.remove('active');
+      loadAudit();
+    }
+
+    function clearAuditBucketFilter() {
+      auditFilterBucket = null;
+      auditCurrentPage = 1;
+      document.getElementById('auditBucketPopover')?.classList.remove('open');
+      document.getElementById('auditBucketSearchTrigger')?.classList.remove('active');
+      loadAudit();
+    }
+
+    function auditStatusChip(status) {
+      if (!status) return '<span class="status-chip">None</span>';
+      const cls = status === 'OptedIn' ? 'opted-in' : status === 'OptedOut' ? 'opted-out' : 'pending';
+      const label = status === 'OptedIn' ? 'Opted in' : status === 'OptedOut' ? 'Opted out' : status;
+      return `<span class="status-chip ${cls}">${label}</span>`;
+    }
+
+    function renderAuditRow(e) {
+      const sourceLabel = { Url: 'User', Api: 'API', Admin: 'Admin' }[e.source] || e.source;
+      const nullCell = '<span class="muted">—</span>';
+      const oldChip = auditStatusChip(e.oldStatus);
+      const newChip = auditStatusChip(e.newStatus);
+      return `
+        <tr>
+          <td>${sanitize(formatDate(e.changedAt))}</td>
+          <td>
+            <span class="tooltip-wrapper"
+              onclick="auditIdentityClick('${sanitize(e.emailHash)}')"
+              ondblclick="auditIdentityDblClick('${sanitize(e.emailHash)}')">
+              <span class="email-hash" style="cursor:pointer">${sanitize(e.displayId)}</span>
+              <span class="tooltip">Click to filter · double-click to copy</span>
+            </span>
+          </td>
+          <td><span class="bucket-name" style="cursor:pointer" onclick="showAuditForBucket('${sanitize(e.bucket)}')">${sanitize(e.bucket)}</span></td>
+          <td><code>${sanitize(e.permission)}</code></td>
+          <td style="white-space:nowrap">${oldChip} → ${newChip}</td>
+          <td>${sanitize(sourceLabel)}</td>
+          <td>${e.actorId ? sanitize(e.actorId) : nullCell}</td>
+          <td>${e.ipAddress ? `<code>${sanitize(e.ipAddress)}</code>` : nullCell}</td>
+        </tr>`;
+    }
+
+    function auditIdentityClick(hash) {
+      clearTimeout(_auditClickTimer);
+      _auditClickTimer = setTimeout(() => showAuditForIdentity(hash), 250);
+    }
+
+    function auditIdentityDblClick(hash) {
+      clearTimeout(_auditClickTimer);
+      copyTextNow(hash);
+    }
+
+    function showAuditForBucket(bucket) {
+      auditFilterBucket = bucket;
+      auditFilterIdentity = null;
+      auditCurrentPage = 1;
+      showView('audit');
+    }
+
+    function showAuditForIdentity(hash) {
+      auditFilterBucket = null;
+      auditFilterIdentity = hash;
+      auditCurrentPage = 1;
+      showView('audit');
+    }
+
+    function showAuditForBucketAndIdentity(bucket, hash) {
+      auditFilterBucket = bucket;
+      auditFilterIdentity = hash;
+      auditCurrentPage = 1;
+      showView('audit');
+    }
+
+    function clearAuditFilter() {
+      auditFilterBucket = null;
+      auditFilterIdentity = null;
+      auditCurrentPage = 1;
+      loadAudit();
+    }
+
+    function updateAuditPageSize() {
+      auditPageSize = parseInt(document.getElementById('auditPageSizeSelect').value);
+      auditCurrentPage = 1;
+      loadAudit();
+    }
+
+    function changeAuditPage(delta) {
+      const maxPage = Math.ceil(auditTotalRecords / auditPageSize) || 1;
+      auditCurrentPage = Math.max(1, Math.min(auditCurrentPage + delta, maxPage));
+      loadAudit();
+    }
+
+    function updateAuditPagination() {
+      const maxPage = Math.ceil(auditTotalRecords / auditPageSize) || 1;
+      const start = auditTotalRecords === 0 ? 0 : (auditCurrentPage - 1) * auditPageSize + 1;
+      const end = Math.min(auditCurrentPage * auditPageSize, auditTotalRecords);
+      const info = document.getElementById('auditPaginationInfo');
+      if (info) info.textContent = auditTotalRecords === 0 ? 'No entries' : `${start}–${end} of ${auditTotalRecords}`;
+      const prev = document.getElementById('auditPrevBtn');
+      const next = document.getElementById('auditNextBtn');
+      if (prev) prev.disabled = auditCurrentPage <= 1;
+      if (next) next.disabled = auditCurrentPage >= maxPage;
+    }
+    // ── /Audit ─────────────────────────────────────────────────────────────
 
     const _workflowTypeLabels = {
       RetentionPurge: 'Opted-out anonymisation',

--- a/Source/Beacon/wwwroot/js/admin.js
+++ b/Source/Beacon/wwwroot/js/admin.js
@@ -927,7 +927,7 @@
             <tr style="cursor:pointer" onclick="showIdentityDetails('${sanitize(id.emailHash)}')">
               <td>${idDisplay}</td>
               <td>${id.bucketCount} bucket${id.bucketCount !== 1 ? 's' : ''}</td>
-              <td>${sanitize(formatDate(id.lastChanged))}</td>
+              <td class="col-link" onclick="event.stopPropagation();showAuditForIdentity('${sanitize(id.emailHash)}')" title="View audit">${sanitize(formatDate(id.lastChanged))}</td>
               <td>
                 <div class="row-actions">
                   <span class="tooltip-wrapper">
@@ -3882,7 +3882,7 @@ ${bodyStr}
     async function loadAudit() {
       const params = new URLSearchParams();
       if (auditFilterBucket) params.set('bucket', auditFilterBucket);
-      if (auditFilterIdentity) params.set('identity', auditFilterIdentity);
+      if (auditFilterIdentity) params.set('emailHash', auditFilterIdentity);
       params.set('page', auditCurrentPage);
       params.set('size', auditPageSize);
 


### PR DESCRIPTION
To make the consent flow more transparent for (backend) users and help reduce confusion or disputes about whether someone opted in or out, this PR aims to add a Audit module: allowing the user to access a simple consent history view that shows when preferences were modified and what changed. 

This respects other modules (e.g. privacy guard in the application settings). 